### PR TITLE
Do not log connector output by default

### DIFF
--- a/Deveroom.VisualStudio/Connectors/OutProcSpecFlowConnector.cs
+++ b/Deveroom.VisualStudio/Connectors/OutProcSpecFlowConnector.cs
@@ -66,7 +66,10 @@ namespace Deveroom.VisualStudio.Connectors
             }
 
             _logger.LogVerbose(connectorPath);
+
+#if DEBUG
             _logger.LogVerbose(result.StandardOut);
+#endif
 
             var discoveryResult = JsonSerialization.DeserializeObjectWithMarker<DiscoveryResult>(result.StandardOut);
             if (discoveryResult.IsFailed)


### PR DESCRIPTION
The current implementation of `OutProcSpecFlowConnector` logs the full output of the specflow connector to the log file, and to VS debug window.

On a project with a lot of tests, each log file can amount to a massive size (on my machine, I have 2.6 GB of Deveroom logs from regular usage since late 2019, and the biggest daily log files are ~160 MB).

This impacts both the machine disk space, and the performance of the extension itself.

Here we adjust `OutProcSpecFlowConnector` to only log in a debug build.