### PR TITLE
Performance of DiscoveryService.CalculateSourceLocationTrackingPositions

### DIFF
--- a/Deveroom.VisualStudio.Package/ProjectSystem/NullVsIdeScope.cs
+++ b/Deveroom.VisualStudio.Package/ProjectSystem/NullVsIdeScope.cs
@@ -1,7 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Threading;
-using Deveroom.VisualStudio.Diagnostics;
 using Deveroom.VisualStudio.Diagonostics;
 using Deveroom.VisualStudio.Discovery;
 using Deveroom.VisualStudio.Monitoring;
@@ -140,9 +140,8 @@ namespace Deveroom.VisualStudio.ProjectSystem
             DeveroomErrorListServices = null;
         }
 
-        public IPersistentSpan CreatePersistentTrackingPosition(SourceLocation sourceLocation)
+        public void CalculateSourceLocationTrackingPositions(IEnumerable<SourceLocation> sourceLocations)
         {
-            return null;
         }
 
         public IProjectScope[] GetProjectsWithFeatureFiles()

--- a/Deveroom.VisualStudio.Package/ProjectSystem/VsIdeScopeLoader.cs
+++ b/Deveroom.VisualStudio.Package/ProjectSystem/VsIdeScopeLoader.cs
@@ -1,10 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.IO.Abstractions;
-using System.Linq;
 using System.Threading;
-using Deveroom.VisualStudio.Diagnostics;
 using Deveroom.VisualStudio.Diagonostics;
 using Deveroom.VisualStudio.Discovery;
 using Deveroom.VisualStudio.Monitoring;
@@ -121,9 +120,9 @@ namespace Deveroom.VisualStudio.ProjectSystem
             remove => VsIdeScope.WeakProjectOutputsUpdated -= value;
         }
 
-        public IPersistentSpan CreatePersistentTrackingPosition(SourceLocation sourceLocation)
+        public void CalculateSourceLocationTrackingPositions(IEnumerable<SourceLocation> sourceLocations)
         {
-            return VsIdeScope.CreatePersistentTrackingPosition(sourceLocation);
+            VsIdeScope.CalculateSourceLocationTrackingPositions(sourceLocations);
         }
 
         public IProjectScope[] GetProjectsWithFeatureFiles()

--- a/Deveroom.VisualStudio.Package/VsUtils.cs
+++ b/Deveroom.VisualStudio.Package/VsUtils.cs
@@ -54,10 +54,8 @@ namespace Deveroom.VisualStudio
             }
         }
 
-        public static IWpfTextView GetWpfTextViewFromFilePath(string filePath, IServiceProvider serviceProvider)
+        public static IWpfTextView GetWpfTextViewFromFilePath(string filePath, IServiceProvider serviceProvider, IVsEditorAdaptersFactoryService editorAdaptersFactoryService)
         {
-            var editorAdaptersFactoryService = ResolveMefDependency<IVsEditorAdaptersFactoryService>(serviceProvider);
-
             if (VsShellUtilities.IsDocumentOpen(serviceProvider, filePath, Guid.Empty,
                 out var _, out var _, out var windowFrame))
             {

--- a/Deveroom.VisualStudio/Discovery/DiscoveryService.cs
+++ b/Deveroom.VisualStudio/Discovery/DiscoveryService.cs
@@ -301,18 +301,8 @@ namespace Deveroom.VisualStudio.Discovery
 
         private void CalculateSourceLocationTrackingPositions(ProjectBindingRegistry bindingRegistry)
         {
-            int counter = 0;
-            foreach (var sourceLocation in bindingRegistry.StepDefinitions.Select(sd => sd.Implementation.SourceLocation)
-                .Where(sl => sl != null))
-            {
-                if (sourceLocation.SourceLocationSpan == null)
-                {
-                    counter++;
-                    sourceLocation.SourceLocationSpan = _projectScope.IdeScope.CreatePersistentTrackingPosition(sourceLocation);
-                }
-            }
-
-            _logger.LogVerbose($"{counter} tracking positions calculated");
+            var sourceLocations = bindingRegistry.StepDefinitions.Select(sd => sd.Implementation.SourceLocation);
+            _projectScope.IdeScope.CalculateSourceLocationTrackingPositions(sourceLocations);
         }
 
         private void DisposeSourceLocationTrackingPositions(ProjectBindingRegistry bindingRegistry)

--- a/Deveroom.VisualStudio/ProjectSystem/IIdeScope.cs
+++ b/Deveroom.VisualStudio/ProjectSystem/IIdeScope.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO.Abstractions;
 using Deveroom.VisualStudio.Diagonostics;
 using Deveroom.VisualStudio.Discovery;
@@ -22,7 +23,7 @@ namespace Deveroom.VisualStudio.ProjectSystem
         event EventHandler<EventArgs> WeakProjectsBuilt;
         event EventHandler<EventArgs> WeakProjectOutputsUpdated;
 
-        IPersistentSpan CreatePersistentTrackingPosition(SourceLocation sourceLocation);
+        void CalculateSourceLocationTrackingPositions(IEnumerable<SourceLocation> sourceLocations);
         IProjectScope[] GetProjectsWithFeatureFiles();
     }
 }

--- a/Tests/Deveroom.VisualStudio.VsxStubs/ProjectSystem/StubIdeScope.cs
+++ b/Tests/Deveroom.VisualStudio.VsxStubs/ProjectSystem/StubIdeScope.cs
@@ -41,9 +41,8 @@ namespace Deveroom.VisualStudio.VsxStubs.ProjectSystem
         public event EventHandler<EventArgs> WeakProjectsBuilt;
         public event EventHandler<EventArgs> WeakProjectOutputsUpdated;
 
-        public IPersistentSpan CreatePersistentTrackingPosition(SourceLocation sourceLocation)
+        public void CalculateSourceLocationTrackingPositions(IEnumerable<SourceLocation> sourceLocations)
         {
-            return null;
         }
 
         public IProjectScope[] GetProjectsWithFeatureFiles()


### PR DESCRIPTION
Profiling on a solution with a lot of Gherkin feature files shows that a significant amount of resources is taken in Deveroom when doing the repeated calls to `ResolveMefDependency` and `GetWpfTextViewFromFilePath` when calculating the tracking positions.

Here we reduce the number of calls to these methods:
- only call `ResolveMefDependency` once for each project being discovered
- group tracking positions by source file, so that we can call `GetWpfTextViewFromFilePath` once per source file only

After these changes, the resource usage for tracking position calculations goes down significantly.